### PR TITLE
Add notebook for SAT POI folium map

### DIFF
--- a/notebook/sat_poi_folium_map.ipynb
+++ b/notebook/sat_poi_folium_map.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4cec4b2",
+   "metadata": {},
+   "source": [
+    "# Stockholm Archipelago Trail POI Map\n",
+    "This notebook fetches Stockholm Archipelago Trail sections from Wikidata and displays drinking water, toilets, restaurants, hotels, campsites and hostels within 500 m of the trail on a Folium map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f4b98e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import requests\n",
+    "import folium\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8a7c518",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_sat_sections_from_wikidata(trail_qid: str = \"Q131318799\") -> pd.DataFrame:\n",
+    "    query = f\"\"\"\n",
+    "    SELECT ?section ?sectionLabel ?osmr ?osmw_p10689 ?osmw_p11693 WHERE {\n",
+    "      VALUES ?trail { wd:{trail_qid} }\n",
+    "      {\n",
+    "        ?section wdt:P361+ ?trail .\n",
+    "      } UNION {\n",
+    "        ?trail wdt:P527 ?section .\n",
+    "      }\n",
+    "      FILTER(?section != ?trail)\n",
+    "      OPTIONAL { ?section wdt:P402 ?osmr }             # OSM relation id\n",
+    "      OPTIONAL { ?section wdt:P10689 ?osmw_p10689 }    # OSM way id (alt 1)\n",
+    "      OPTIONAL { ?section wdt:P11693 ?osmw_p11693 }    # OSM way id (alt 2)\n",
+    "      SERVICE wikibase:label { bd:serviceParam wikibase:language \"sv,en\". }\n",
+    "    }\n",
+    "    ORDER BY ?sectionLabel\n",
+    "    \"\"\"\n",
+    "    url = \"https://query.wikidata.org/sparql\"\n",
+    "    headers = {\"Accept\": \"application/sparql-results+json\"}\n",
+    "    response = requests.get(url, params={\"query\": query}, headers=headers)\n",
+    "    response.raise_for_status()\n",
+    "    data = response.json()\n",
+    "    rows = []\n",
+    "    for item in data['results']['bindings']:\n",
+    "        rows.append({\n",
+    "            'section': item['section']['value'],\n",
+    "            'sectionLabel': item.get('sectionLabel', {}).get('value'),\n",
+    "            'osmr': item.get('osmr', {}).get('value'),\n",
+    "            'osmw_p10689': item.get('osmw_p10689', {}).get('value'),\n",
+    "            'osmw_p11693': item.get('osmw_p11693', {}).get('value'),\n",
+    "        })\n",
+    "    df = pd.DataFrame(rows)\n",
+    "    for col in ['osmr','osmw_p10689','osmw_p11693']:\n",
+    "        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Int64')\n",
+    "    return df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc7ba511",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sections_df = fetch_sat_sections_from_wikidata()\n",
+    "sections_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02081234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_pois_for_section(osm_id: int, id_type: str, dist: int = 500):\n",
+    "    if id_type == 'relation':\n",
+    "        pivot = f'way(r:{osm_id})'\n",
+    "    else:\n",
+    "        pivot = f'way({osm_id})'\n",
+    "    query = f\"\"\"\n",
+    "    [out:json][timeout:25];\n",
+    "    {pivot}->.trail;\n",
+    "    (\n",
+    "      nwr(around:{dist}, .trail)[\"amenity\"=\"drinking_water\"];\n",
+    "      nwr(around:{dist}, .trail)[\"amenity\"=\"toilets\"];\n",
+    "      nwr(around:{dist}, .trail)[\"amenity\"=\"restaurant\"];\n",
+    "      nwr(around:{dist}, .trail)[\"tourism\"=\"hotel\"];\n",
+    "      nwr(around:{dist}, .trail)[\"tourism\"=\"camp_site\"];\n",
+    "      nwr(around:{dist}, .trail)[\"tourism\"=\"hostel\"];\n",
+    "    );\n",
+    "    out center tags;\n",
+    "    \"\"\"\n",
+    "    response = requests.get('https://overpass-api.de/api/interpreter', params={'data': query})\n",
+    "    response.raise_for_status()\n",
+    "    data = response.json()\n",
+    "    pois = []\n",
+    "    for el in data['elements']:\n",
+    "        if 'lat' in el and 'lon' in el:\n",
+    "            lat, lon = el['lat'], el['lon']\n",
+    "        elif 'center' in el:\n",
+    "            lat, lon = el['center']['lat'], el['center']['lon']\n",
+    "        else:\n",
+    "            continue\n",
+    "        tags = el.get('tags', {})\n",
+    "        tags.update({'osm_id': el['id'], 'osm_type': el['type']})\n",
+    "        pois.append({'lat': lat, 'lon': lon, **tags})\n",
+    "    return pois\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "008d4dae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pois = []\n",
+    "for _, row in sections_df.iterrows():\n",
+    "    if pd.notnull(row['osmr']):\n",
+    "        all_pois.extend(fetch_pois_for_section(int(row['osmr']), 'relation'))\n",
+    "    elif pd.notnull(row['osmw_p10689']):\n",
+    "        all_pois.extend(fetch_pois_for_section(int(row['osmw_p10689']), 'way'))\n",
+    "    elif pd.notnull(row['osmw_p11693']):\n",
+    "        all_pois.extend(fetch_pois_for_section(int(row['osmw_p11693']), 'way'))\n",
+    "poi_df = pd.DataFrame(all_pois)\n",
+    "poi_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e2556e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = folium.Map(location=[59.3, 18.0], zoom_start=8)\n",
+    "category_colors = {\n",
+    "    'drinking_water': 'blue',\n",
+    "    'toilets': 'green',\n",
+    "    'restaurant': 'red',\n",
+    "    'hotel': 'purple',\n",
+    "    'camp_site': 'orange',\n",
+    "    'hostel': 'gray',\n",
+    "}\n",
+    "for _, feature in poi_df.iterrows():\n",
+    "    lat, lon = feature['lat'], feature['lon']\n",
+    "    if feature.get('amenity') in category_colors:\n",
+    "        key = feature['amenity']\n",
+    "    elif feature.get('tourism') in category_colors:\n",
+    "        key = feature['tourism']\n",
+    "    else:\n",
+    "        continue\n",
+    "    folium.CircleMarker([lat, lon], radius=5, color=category_colors[key], fill=True, fill_color=category_colors[key], popup=key).add_to(m)\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fe813c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.save('../html/sat_poi_map.html')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- notebook to fetch SAT sections from Wikidata and map nearby amenities
- query Overpass for water, toilets, restaurants, hotels, campsites and hostels within 500 m of the trail
- render results on interactive Folium map and save to HTML

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68bdb8c82c90832d8f6e907b9901ef07